### PR TITLE
fix: Rollout deployment restart was not working as expected

### DIFF
--- a/examples/gateway-complete.yaml
+++ b/examples/gateway-complete.yaml
@@ -20,9 +20,10 @@ metadata:
 spec:
   # Core gateway configuration
   environment: production
+  # replicas: 3
   hpa:
     enabled: true
-    minReplicas: 1
+    minReplicas: 3
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
   image: "ghcr.io/inference-gateway/inference-gateway:0.12.0"

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -575,7 +575,15 @@ func (r *GatewayReconciler) updateDeploymentIfNeeded(ctx context.Context, gatewa
 		}
 
 		if !reflect.DeepEqual(latestDeployment.Spec.Template, desired.Spec.Template) {
+			existingAnnotations := latestDeployment.Spec.Template.Annotations
+			if existingAnnotations == nil {
+				existingAnnotations = map[string]string{}
+			}
+			for k, v := range desired.Spec.Template.Annotations {
+				existingAnnotations[k] = v
+			}
 			latestDeployment.Spec.Template = desired.Spec.Template
+			latestDeployment.Spec.Template.Annotations = existingAnnotations
 			needsUpdate = true
 			changes = append(changes, "pod template")
 		}


### PR DESCRIPTION
## Summary

The fix - preserve existing annotations when updating deployment template.

Instead of completely disregarding existing annotations.

When the client sends a `kubectl rollout restart deployment <deployment>` an annotation restartedAt with timestamp is added to the deployment. This was completely disregarded, now it's fixed.