### PR TITLE
docs(examples): Add Google provider support

### DIFF
--- a/examples/gateway-complete.yaml
+++ b/examples/gateway-complete.yaml
@@ -143,6 +143,19 @@ spec:
             secretKeyRef:
               name: inference-gateway-providers-secret
               key: OLLAMA_API_KEY
+    - name: Google
+      enabled: true
+      env:
+        - name: GOOGLE_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: inference-gateway-config
+              key: GOOGLE_API_URL
+        - name: GOOGLE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: inference-gateway-providers-secret
+              key: GOOGLE_API_KEY
     - name: Custom
       enabled: true
       env:
@@ -244,6 +257,7 @@ stringData:
 #   CLOUDFLARE_API_KEY: ""
 #   DEEPSEEK_API_KEY: ""
 #   OLLAMA_API_KEY: ""
+#   GOOGLE_API_KEY: ""
 #   CUSTOM_API_KEY: ""
 ---
 apiVersion: v1
@@ -259,4 +273,5 @@ data:
   CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai"
   DEEPSEEK_API_URL: "https://api.deepseek.com"
   OLLAMA_API_URL: "http://ollama:11434/v1"
+  GOOGLE_API_URL: "https://generativelanguage.googleapis.com/v1"
   CUSTOM_API_URL: "http://your-domain.example.local:8080/v1"

--- a/examples/gateway-google.yaml
+++ b/examples/gateway-google.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inference-gateway
+  labels:
+    inference-gateway.com/managed: "true"
+---
+apiVersion: core.inference-gateway.com/v1alpha1
+kind: Gateway
+metadata:
+  name: google-gateway
+  namespace: inference-gateway
+spec:
+  replicas: 1
+  image: "ghcr.io/inference-gateway/inference-gateway:latest"
+  environment: development
+  telemetry:
+    enabled: true
+    metrics:
+      enabled: true
+      port: 9464
+  server:
+    host: "0.0.0.0"
+    port: 8080
+  providers:
+    - name: Google
+      env:
+        - name: GOOGLE_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: inference-gateway-config
+              key: api_url
+        - name: GOOGLE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: google-secret
+              key: api_key
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-secret
+  namespace: inference-gateway
+type: Opaque
+stringData:
+  api_key: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inference-gateway-config
+  namespace: inference-gateway
+data:
+  api_url: "https://generativelanguage.googleapis.com/v1"


### PR DESCRIPTION
Added Google provider support to the examples:

- Added Google provider to gateway-complete.yaml example
- Created dedicated gateway-google.yaml example for Google provider
- Added Google API URL and key configuration following existing patterns

Closes #17

Generated with [Claude Code](https://claude.ai/code)