### PR TITLE
refactor(a2a): Remove A2A_SERVICE_DISCOVERY_ENDPOINTS environment variable

### DIFF
--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -352,8 +352,6 @@ func (r *GatewayReconciler) buildDeployment(ctx context.Context, gateway *corev1
 
 // buildContainer creates the main container specification with custom volume mounts
 func (r *GatewayReconciler) buildContainer(ctx context.Context, gateway *corev1alpha1.Gateway, containerPorts []corev1.ContainerPort, volumeMounts []corev1.VolumeMount) corev1.Container { //nolint gocyclo
-	logger := log.FromContext(ctx)
-
 	port := int32(8080)
 	if gateway.Spec.Server != nil && gateway.Spec.Server.Port > 0 {
 		port = gateway.Spec.Server.Port
@@ -526,12 +524,6 @@ func (r *GatewayReconciler) buildContainer(ctx context.Context, gateway *corev1a
 				namespace = "default"
 			}
 
-			endpoints, err := r.discoverA2AEndpoints(ctx, namespace)
-			if err != nil {
-				logger.Error(err, "failed to discover A2A endpoints", "namespace", namespace)
-				endpoints = []string{}
-			}
-
 			envVars = append(envVars,
 				corev1.EnvVar{
 					Name:  "A2A_SERVICE_DISCOVERY_ENABLE",
@@ -540,10 +532,6 @@ func (r *GatewayReconciler) buildContainer(ctx context.Context, gateway *corev1a
 				corev1.EnvVar{
 					Name:  "A2A_SERVICE_DISCOVERY_NAMESPACE",
 					Value: namespace,
-				},
-				corev1.EnvVar{
-					Name:  "A2A_SERVICE_DISCOVERY_ENDPOINTS",
-					Value: strings.Join(endpoints, ","),
 				},
 				corev1.EnvVar{
 					Name: "A2A_SERVICE_DISCOVERY_POLLING_INTERVAL",
@@ -1255,37 +1243,6 @@ func (r *GatewayReconciler) buildContainerPorts(gateway *corev1alpha1.Gateway) [
 	}
 
 	return ports
-}
-
-// discoverA2AEndpoints discovers A2A CRDs and their associated services in the specified namespace
-func (r *GatewayReconciler) discoverA2AEndpoints(ctx context.Context, namespace string) ([]string, error) {
-	logger := log.FromContext(ctx)
-
-	a2aList := &corev1alpha1.A2AList{}
-	if err := r.List(ctx, a2aList, client.InNamespace(namespace)); err != nil {
-		logger.Error(err, "failed to list A2A resources", "namespace", namespace)
-		return nil, err
-	}
-
-	endpoints := make([]string, 0, len(a2aList.Items))
-	for _, a2a := range a2aList.Items {
-		svc := &corev1.Service{}
-		svcName := a2a.Name
-		if err := r.Get(ctx, client.ObjectKey{Namespace: a2a.Namespace, Name: svcName}, svc); err != nil {
-			if errors.IsNotFound(err) {
-				logger.V(1).Info("service not found for A2A resource", "a2a", a2a.Name, "namespace", a2a.Namespace)
-				continue
-			}
-			logger.Error(err, "failed to get service for A2A resource", "a2a", a2a.Name, "namespace", a2a.Namespace)
-			continue
-		}
-
-		endpoint := fmt.Sprintf("%s.%s.svc.cluster.local:8080", svc.Name, svc.Namespace)
-		endpoints = append(endpoints, endpoint)
-		logger.V(1).Info("discovered A2A endpoint", "a2a", a2a.Name, "endpoint", endpoint)
-	}
-
-	return endpoints, nil
 }
 
 // reconcileRBAC manages RBAC resources (ServiceAccount, Role, RoleBinding) for the Gateway

--- a/internal/controller/gateway_controller_test.go
+++ b/internal/controller/gateway_controller_test.go
@@ -541,7 +541,6 @@ var _ = Describe("Gateway controller", func() {
 				{Name: "A2A_CLIENT_TIMEOUT", Value: "5s"},
 				{Name: "A2A_SERVICE_DISCOVERY_ENABLE", Value: "true"},
 				{Name: "A2A_SERVICE_DISCOVERY_NAMESPACE", Value: "test-namespace"},
-				{Name: "A2A_SERVICE_DISCOVERY_ENDPOINTS", Value: ""},
 				{Name: "A2A_SERVICE_DISCOVERY_POLLING_INTERVAL", Value: "60s"},
 			}
 
@@ -582,7 +581,6 @@ var _ = Describe("Gateway controller", func() {
 				{Name: "A2A_CLIENT_TIMEOUT", Value: "5s"},
 				{Name: "A2A_SERVICE_DISCOVERY_ENABLE", Value: "true"},
 				{Name: "A2A_SERVICE_DISCOVERY_NAMESPACE", Value: "default"},
-				{Name: "A2A_SERVICE_DISCOVERY_ENDPOINTS", Value: ""},
 				{Name: "A2A_SERVICE_DISCOVERY_POLLING_INTERVAL", Value: "30s"},
 			}
 


### PR DESCRIPTION
Since this environment variable doesn't exist on the Inference Gateway and auto service discovery is being used, it's not needed.

## Changes
- Removed A2A_SERVICE_DISCOVERY_ENDPOINTS env var from gateway controller
- Removed endpoints discovery logic and unused discoverA2AEndpoints function
- Updated test expectations to remove A2A_SERVICE_DISCOVERY_ENDPOINTS
- Fixed unused logger variable

Closes #29

Generated with [Claude Code](https://claude.ai/code)