### PR TITLE
ci: install prettier in infer/claude agent runs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,6 +51,7 @@ jobs:
     uses: inference-gateway/.github/.github/workflows/claude.yml@main
     with:
       language: "go"
+      prettier: true
       plugins: |
         DietrichGebert/ponytail
       browser: ${{ inputs.browser || false }}

--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -50,6 +50,7 @@ jobs:
     uses: inference-gateway/.github/.github/workflows/infer.yml@main
     with:
       language: "go"
+      prettier: true
       plugins: |
         DietrichGebert/ponytail
       prompt: ${{ inputs.prompt }}


### PR DESCRIPTION
The `language: go` preset in the org reusable agent workflows does not install prettier, but this repo's `task manifests` runs `prettier --write config/**/*.yaml` — so agent runs that touch API types couldn't regenerate manifests cleanly and failed the "Generate & Verify Clean State" check.

Adds `prettier: true` to both thin callers. Source of truth updated in inference-gateway/.github#111 so the next migrate fan-out renders the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)