### PR TITLE
fix(ci): attach release manifests via semantic-release assets

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -52,14 +52,6 @@ jobs:
         run: |
           goreleaser release --clean
 
-      - name: Upload installation manifests to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: |
-          gh release upload ${TAG} manifests/crds.yaml --clobber
-          gh release upload ${TAG} manifests/install.yaml --clobber
-
       - name: Push container images
         env:
           TAG: ${{ github.event.release.tag_name }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -52,6 +52,8 @@ plugins:
   - - "@semantic-release/github"
     - assets:
         - CHANGELOG.md
+        - manifests/crds.yaml
+        - manifests/install.yaml
       releasedLabels: ["released"]
       releaseNameTemplate: "🚀 Version <%= nextRelease.version %>"
       releaseBodyTemplate: |


### PR DESCRIPTION
## Problem

Release run [29682055633](https://github.com/inference-gateway/operator/actions/runs/29682055633/job/88179827243) failed with `HTTP 422: Cannot upload assets to an immutable release` — the Artifacts workflow ran `gh release upload` after semantic-release had already published the (immutable) release.

## Fix

Same pattern already applied in `cli`, `inference-gateway`, and `schemas`:

- Add `manifests/crds.yaml` and `manifests/install.yaml` to the `@semantic-release/github` `assets` list so they're attached at release creation, before the release becomes immutable. They're version-controlled, so no build step is needed; download URLs are unchanged.
- Remove the now-failing upload step from `artifacts.yml`. GoReleaser there has `release: disable: true` (images only), so the rest is unaffected.

Takes effect from the next release; v0.19.0's assets cannot be backfilled.

no docs ticket: internal-only CI fix